### PR TITLE
Multiword controller names handled properly (foo_bar now matches class FooBar)

### DIFF
--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -141,8 +141,10 @@ class Dispatcher
 			// explode out our route parts in case there are any namespaces
 			$controller_parts = explode('\\', $route->params['controller']);
 
-			// only run strtolower/ucfirst on the last part since that is the controller
-			$controller_parts[count($controller_parts) - 1] = ucfirst(strtolower($controller_parts[count($controller_parts) - 1]));
+            // only convert on the last part since that is the controller
+            // ucfirst after camel_case because laravel's camel_case doesn't
+            // uppercase the first letter
+            $controller_parts[count($controller_parts) - 1] = ucfirst(camel_case(($controller_parts[count($controller_parts) - 1])));
 
 			// put back together the route parts
 			$controller = implode('\\', $controller_parts);

--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -144,7 +144,7 @@ class Dispatcher
             // only convert on the last part since that is the controller
             // ucfirst after camel_case because laravel's camel_case doesn't
             // uppercase the first letter
-            $controller_parts[count($controller_parts) - 1] = ucfirst(camel_case(($controller_parts[count($controller_parts) - 1])));
+            $controller_parts[count($controller_parts) - 1] = ucfirst(camel_case($controller_parts[count($controller_parts) - 1]));
 
 			// put back together the route parts
 			$controller = implode('\\', $controller_parts);


### PR DESCRIPTION
When we determine the route action, we're now converting multiple_name_controller to MultipleNameController in a similar fashion to other frameworks. This is done via Laravel's camel_case followed by ucfirst since camel_case returns multipleNameController rather than MultipleNameController.

It has no effect on single word controllers, so multiplenamecontroller would still return Multiplenamecontroller like all existing code.